### PR TITLE
Revert "Merge pull request #96 from velrest/fix-dashboard-route"

### DIFF
--- a/frontend/app/components/dashboard-rt/component.js
+++ b/frontend/app/components/dashboard-rt/component.js
@@ -13,7 +13,8 @@ export default Component.extend({
   fetchTickets: task(function*() {
     return yield this.store.query('rt-ticket', {
       page_size: 3,
-      page: 1
+      page: 1,
+      statistics: true
     })
   })
 })

--- a/frontend/app/dashboard/template.hbs
+++ b/frontend/app/dashboard/template.hbs
@@ -3,13 +3,13 @@
 <section>
   <div>
     <div uk-grid="masonry:true" class="uk-child-width-1-1 uk-child-width-1-2@m" >
-        {{#if (get (await session.user) 'timed')}}
+        {{#if (and (service-enabled 'timed') (get (await session.user) 'timed'))}}
           <div class="uk-padding uk-padding-remove-bottom">
             {{dashboard-timed user=(await session.user)}}
           </div>
         {{/if}}
 
-        {{#if (get (await session.user) 'rt')}}
+        {{#if (and (service-enabled 'rt') (get (await session.user) 'rt'))}}
           <div class="uk-padding uk-padding-remove-bottom">
             {{dashboard-rt}}
           </div>

--- a/frontend/app/notfound/template.hbs
+++ b/frontend/app/notfound/template.hbs
@@ -7,7 +7,7 @@
     <img src="/assets/pictures/404.svg" class="uk-width-1-1 uk-width-medium@s">
   </p>
 
-  {{#link-to 'index' class='uk-button uk-button-primary'}}
+  {{#link-to 'dashboard' class='uk-button uk-button-primary'}}
     Back to Home
   {{/link-to}}
 </div>

--- a/frontend/mirage/config.js
+++ b/frontend/mirage/config.js
@@ -212,7 +212,7 @@ export default function() {
     '/proxy/rt/tickets',
     (
       { rtTickets },
-      { queryParams: { page_size: pageSize, page, status, search } }
+      { queryParams: { page_size: pageSize, page, status, search, statistics } }
     ) => {
       let tickets = rtTickets.all()
 
@@ -228,16 +228,18 @@ export default function() {
 
       let json = _pagination(tickets, page, pageSize)
 
-      json.meta.statistics = {
-        'in-progress': 132,
-        all: 393,
-        states: {
-          new: 21,
-          open: 89,
-          stalled: 92,
-          resolved: 21,
-          rejected: 2,
-          deleted: 83
+      if (statistics) {
+        json.meta.statistics = {
+          'in-progress': 132,
+          all: 393,
+          states: {
+            new: 21,
+            open: 89,
+            stalled: 92,
+            resolved: 21,
+            rejected: 2,
+            deleted: 83
+          }
         }
       }
 


### PR DESCRIPTION
This reverts commit 5f8ddb6418d7119b418abb64926014fd9d3218fc, reversing
changes made to c6b822e805851670e35adf206fd4a9a7ff28158b.

We will still need the statistics param in the backend due to performace problems.