### PR TITLE
feat(sentry): make email field searchable in sentry

### DIFF
--- a/backend/src/timed/proxy.js
+++ b/backend/src/timed/proxy.js
@@ -66,8 +66,8 @@ function reportInvalidAccess(req, access, route) {
   captureExceptionWithUser(req.user, function(scope) {
     scope.setLevel('info')
 
+    scope.setTag('request', `${req.method} ${req.path}`)
     scope.setExtra('role', access)
-    scope.setExtra('request', `${req.method} ${req.path}`)
     scope.setExtra(
       'request-route-access',
       JSON.stringify(

--- a/backend/src/utils/sentry.js
+++ b/backend/src/utils/sentry.js
@@ -3,8 +3,8 @@ import * as Sentry from '@sentry/node'
 export function captureExceptionWithUser(user, fn) {
   Sentry.withScope(function(scope) {
     scope.setTag('user', user.get('username'))
+    scope.setTag('email', user.get('email'))
     scope.setExtra('userData', {
-      email: user.get('email'),
       roles: user.getGroupNames(),
       isAdsyUser: user.isAdsyUser(),
       isAdmin: user.isAdmin(),


### PR DESCRIPTION
the email field in `userData` is sadly not searchable since its just a JSON string. We now set it separately as a tag which allows us in sentry to filter by email.