### PR TITLE
fix: filter non-existant orders

### DIFF
--- a/frontend/app/models/timed-subscription-project.js
+++ b/frontend/app/models/timed-subscription-project.js
@@ -20,6 +20,7 @@ export default Model.extend({
 
   unconfirmedTime: computed('orders', function() {
     return this.orders
+      .filter(order => order !== null)
       .filter(order => !order.get('acknowledged'))
       .reduce((accumulator, order) => {
         return accumulator.add(order.get('duration'))


### PR DESCRIPTION
This problem was reported through Sentry.