### PR TITLE
feat(frontend): make breadcrumbs home an icon

### DIFF
--- a/frontend/app/styles/components/nav-breadcrumbs.scss
+++ b/frontend/app/styles/components/nav-breadcrumbs.scss
@@ -1,4 +1,18 @@
-.breadcrumbs__list {
-  @extend .uk-breadcrumb;
-  @extend .uk-margin-medium-bottom;
+.breadcrumbs {
+  &__list {
+    @extend .uk-breadcrumb;
+    @extend .uk-margin-medium-bottom;
+  }
+
+  &__home {
+    a {
+      vertical-align: text-bottom;
+    }
+
+    svg {
+      width: 18px;
+      height: 17px;
+      max-width: none;
+    }
+  }
 }

--- a/frontend/app/ui/components/nav-breadcrumbs/template.hbs
+++ b/frontend/app/ui/components/nav-breadcrumbs/template.hbs
@@ -1,9 +1,7 @@
 <nav class="breadcrumbs">
   <ol class="breadcrumbs__list">
     <li class="breadcrumbs__home">
-      <LinkTo @route="index">
-        {{~t "component.nav-breadcrumbs.home"}}
-      </LinkTo>
+      <LinkTo @route="index" uk-icon="home"></LinkTo>
     </li>
 
     {{#each @crumbs as |crumb|}}


### PR DESCRIPTION
This makes the breadcrumbs shorter. Plus, the home
route is only a redirect anyway. Not something I want
to give real-estate to.