### PR TITLE
feat(frontend): add load-more to detail page

### DIFF
--- a/frontend/app/services/timed.js
+++ b/frontend/app/services/timed.js
@@ -48,15 +48,19 @@ export default class TimedService extends Service {
       ordering: "-date",
       page: {
         number: page,
-        size: 20,
+        size: 5,
       },
     });
   }
 
-  async getProjectOrders(project) {
+  async getProjectOrders(project, page = 1) {
     return await this.store.query("subscription-order", {
       ordering: "-ordered",
       project,
+      page: {
+        number: page,
+        size: 5,
+      },
     });
   }
 

--- a/frontend/app/styles/app.scss
+++ b/frontend/app/styles/app.scss
@@ -89,6 +89,10 @@ body {
   th {
     @extend .uk-text-nowrap;
   }
+
+  &__fetch-more {
+    @extend .uk-text-center;
+  }
 }
 
 .form {

--- a/frontend/app/ui/subscriptions/detail/controller.js
+++ b/frontend/app/ui/subscriptions/detail/controller.js
@@ -11,8 +11,8 @@ export default class SubscriptionsDetailController extends Controller {
 
   @tracked project;
   @tracked orders;
+  @tracked ordersNext;
   @tracked reports;
-  @tracked reportsPage;
   @tracked reportsNext;
 
   breadcrumbs = [
@@ -22,22 +22,39 @@ export default class SubscriptionsDetailController extends Controller {
 
   @task *fetchNextReports() {
     try {
-      const reports = yield this.timed.getProjectReports(this.reportsPage++);
+      this.reportsPage++;
+      const reports = yield this.timed.getProjectReports(this.reportsPage);
       this.reports.pushObjects(reports.toArray());
 
-      this.reportsNext = get(reports, "links.next");
+      this.reportsNext = Boolean(get(reports, "links.next"));
     } catch (error) {
       console.error(error);
       this.reportsNext = false;
     }
   }
 
+  @task *fetchNextOrders() {
+    try {
+      this.ordersPage++;
+      const orders = yield this.timed.getProjectOrders(this.ordersPage);
+      this.orders.pushObjects(orders.toArray());
+
+      this.ordersNext = Boolean(get(orders, "links.next"));
+    } catch (error) {
+      console.error(error);
+      this.ordersNext = false;
+    }
+  }
+
   setup(model, transition) {
     this.project = model.project;
-    this.orders = model.orders;
 
     this.reports = model.reports.toArray();
     this.reportsPage = 1;
     this.reportsNext = Boolean(get(model, "reports.links.next"));
+
+    this.orders = model.orders.toArray();
+    this.ordersPage = 1;
+    this.ordersNext = Boolean(get(model, "orders.links.next"));
   }
 }

--- a/frontend/app/ui/subscriptions/detail/template.hbs
+++ b/frontend/app/ui/subscriptions/detail/template.hbs
@@ -38,84 +38,104 @@
 <section class="section">
   <div class="section__inner">
 
-    <h2 class="section__title">
-      {{~t "page.subscriptions.detail.orders.title"~}}
-    </h2>
+    <div
+      class="
+        uk-child-width-1-1
+        uk-child-width-1-2@m
+      "
+      uk-grid
+    >
+      <div>
+        <h2 class="section__title">
+          {{~t "page.subscriptions.detail.orders.title"~}}
+        </h2>
 
-    {{#if this.orders.length}}
-      <div class="table">
-        <table>
-          <thead>
-            <th>{{t "page.subscriptions.detail.orders.table.date"}}</th>
-            <th>{{t "page.subscriptions.detail.orders.table.duration"}}</th>
-            <th>{{t "page.subscriptions.detail.orders.table.acknowledged"}}</th>
-          </thead>
-          <tbody>
-            {{#each this.orders as |order|}}
-              <tr>
-                <td>{{moment-format order.ordered "DD.MM.YYYY"}}</td>
-                <td>{{format-duration order.duration}}</td>
-                <td class="order-list--{{if order.acknowledged "acknowledged" "pending"}}">
-                  <span uk-icon={{if order.acknowledged "check" "clock"}}></span>
-                </td>
-              </tr>
-            {{/each}}
-          </tbody>
-        </table>
+        {{#if this.orders.length}}
+          <div class="table">
+            <table>
+              <thead>
+                <th>{{t "page.subscriptions.detail.orders.table.date"}}</th>
+                <th>{{t "page.subscriptions.detail.orders.table.duration"}}</th>
+                <th>{{t "page.subscriptions.detail.orders.table.acknowledged"}}</th>
+              </thead>
+              <tbody>
+                {{#each this.orders as |order|}}
+                  <tr>
+                    <td>{{moment-format order.ordered "DD.MM.YYYY"}}</td>
+                    <td>{{format-duration order.duration}}</td>
+                    <td class="order-list--{{if order.acknowledged "acknowledged" "pending"}}">
+                      <span uk-icon={{if order.acknowledged "check" "clock"}}></span>
+                    </td>
+                  </tr>
+                {{/each}}
+
+                {{#if this.ordersNext}}
+                  <tr class="table__fetch-more">
+                    <td colspan="3">
+                      <button
+                        {{on "click" (perform this.fetchNextOrders)}}
+                        type="button"
+                        class="button"
+                        disabled={{this.fetchNextOrders.isRunning}}
+                      >
+                        {{~t "page.subscriptions.detail.orders.more"}}
+                      </button>
+                    </td>
+                  </tr>
+                {{/if}}
+              </tbody>
+            </table>
+          </div>
+        {{else}}
+          <p>{{t "page.subscriptions.detail.orders.empty"}}</p>
+        {{/if}}
       </div>
-    {{else}}
-      <p>{{t "page.subscriptions.detail.orders.empty"}}</p>
-    {{/if}}
+      <div>
+        <h2 class="section__title">
+          {{~t "page.subscriptions.detail.reports.title"~}}
+        </h2>
 
-  </div>
-</section>
+        {{#if this.reports.length}}
+          <div class="table">
+            <table>
+              <thead>
+                <th>{{t "page.subscriptions.detail.reports.table.date"}}</th>
+                <th>{{t "page.subscriptions.detail.reports.table.duration"}}</th>
+                <th>{{t "page.subscriptions.detail.reports.table.user"}}</th>
+                <th>{{t "page.subscriptions.detail.reports.table.comment"}}</th>
+              </thead>
+              <tbody>
+                {{#each this.reports as |report|}}
+                  <tr>
+                    <td>{{moment-format report.date "DD.MM.YYYY"}}</td>
+                    <td>{{format-duration report.duration}}</td>
+                    <td>{{report.user.fullName}}</td>
+                    <td>{{report.comment}}</td>
+                  </tr>
+                {{/each}}
 
-<section class="section">
-  <div class="section__inner">
-
-    <h2 class="section__title">
-      {{~t "page.subscriptions.detail.reports.title"~}}
-    </h2>
-
-    {{#if this.reports.length}}
-      <div class="table">
-        <table>
-          <thead>
-            <th>{{t "page.subscriptions.detail.reports.table.date"}}</th>
-            <th>{{t "page.subscriptions.detail.reports.table.duration"}}</th>
-            <th>{{t "page.subscriptions.detail.reports.table.user"}}</th>
-            <th>{{t "page.subscriptions.detail.reports.table.comment"}}</th>
-          </thead>
-          <tbody>
-            {{#each this.reports as |report|}}
-              <tr>
-                <td>{{moment-format report.date "DD.MM.YYYY"}}</td>
-                <td>{{format-duration report.duration}}</td>
-                <td>{{report.user.fullName}}</td>
-                <td>{{report.comment}}</td>
-              </tr>
-            {{/each}}
-
-            {{#if this.reportsNext}}
-              <tr>
-                <td colspan="4">
-                  <button
-                    {{on "click" (perform this.fetchNextReports)}}
-                    type="button"
-                    class="button"
-                    disabled={{this.fetchNextReports.isRunning}}
-                  >
-                    {{~t "page.subscriptions.detail.reports.more"}}
-                  </button>
-                </td>
-              </tr>
-            {{/if}}
-          </tbody>
-        </table>
+                {{#if this.reportsNext}}
+                  <tr class="table__fetch-more">
+                    <td colspan="4">
+                      <button
+                        {{on "click" (perform this.fetchNextReports)}}
+                        type="button"
+                        class="button"
+                        disabled={{this.fetchNextReports.isRunning}}
+                      >
+                        {{~t "page.subscriptions.detail.reports.more"}}
+                      </button>
+                    </td>
+                  </tr>
+                {{/if}}
+              </tbody>
+            </table>
+          </div>
+        {{else}}
+          <p>{{t "page.subscriptions.detail.reports.empty"}}</p>
+        {{/if}}
       </div>
-    {{else}}
-      <p>{{t "page.subscriptions.detail.reports.empty"}}</p>
-    {{/if}}
+    </div>
 
   </div>
 </section>

--- a/frontend/tests/unit/ui/subscriptions/detail/controller-test.js
+++ b/frontend/tests/unit/ui/subscriptions/detail/controller-test.js
@@ -17,6 +17,7 @@ module("Unit | Controller | subscriptions/detail", function (hooks) {
 
     const project = {};
     const orders = [];
+    orders.links = { next: "..." };
     const reports = [];
     reports.links = { next: "..." };
 
@@ -24,7 +25,10 @@ module("Unit | Controller | subscriptions/detail", function (hooks) {
     controller.setup(model);
 
     assert.equal(controller.project, project);
-    assert.equal(controller.orders, orders);
+
+    assert.deepEqual(controller.orders, orders.toArray());
+    assert.equal(controller.ordersPage, 1);
+    assert.equal(controller.ordersNext, true);
 
     assert.deepEqual(controller.reports, reports.toArray());
     assert.equal(controller.reportsPage, 1);


### PR DESCRIPTION
Depends on #144 

To limit the initial requests. Additionally, this
updates the markup to have orders and reports
side-by-side on larger viewports.