### PR TITLE
fix(frontend): don't change locale if user has no language

### DIFF
--- a/frontend/app/services/account.js
+++ b/frontend/app/services/account.js
@@ -48,8 +48,11 @@ export default class AccountService extends Service {
       this.info = this.store.peekRecord("user", id);
 
       const { language } = this.info;
-      this.intl.setLocale(language);
-      this.moment.setLocale(language);
+
+      if (language) {
+        this.intl.setLocale(language);
+        this.moment.setLocale(language);
+      }
     } catch (error) {
       console.error(error);
       this.notify.fromError(error);


### PR DESCRIPTION
A user might not have a language saved with his profile.
This currently results in the account service settings the
locale to null.