### PR TITLE
feat(frontend): add date field to reload form

### DIFF
--- a/frontend/app/services/timed.js
+++ b/frontend/app/services/timed.js
@@ -83,10 +83,11 @@ export default class TimedService extends Service {
     return packages;
   }
 
-  async placeSubscriptionOrder(project, duration) {
+  async placeSubscriptionOrder(project, duration, ordered) {
     const order = this.store.createRecord("subscription-order", {
       duration,
       project,
+      ordered,
     });
 
     await order.save();

--- a/frontend/app/ui/subscriptions/reload/controller.js
+++ b/frontend/app/ui/subscriptions/reload/controller.js
@@ -1,6 +1,7 @@
 import Controller from "@ember/controller";
 import { action } from "@ember/object";
 import { inject as service } from "@ember/service";
+import { isEmpty } from "@ember/utils";
 import { tracked } from "@glimmer/tracking";
 import { Changeset } from "ember-changeset";
 import moment from "moment";
@@ -39,8 +40,9 @@ export default class SubscriptionsReloadController extends Controller {
 
     try {
       const duration = moment.duration({ hours, minutes });
+      const ordered = isEmpty(date) ? undefined : moment(date);
 
-      await this.timed.placeSubscriptionOrder(this.project, duration);
+      await this.timed.placeSubscriptionOrder(this.project, duration, ordered);
 
       this.notify.success(
         this.intl.t("page.subscriptions.reload.form.success")
@@ -75,6 +77,7 @@ export default class SubscriptionsReloadController extends Controller {
     this.changeset = new Changeset({
       hours: 0,
       minutes: 0,
+      date: "",
     });
   }
 }

--- a/frontend/app/ui/subscriptions/reload/template.hbs
+++ b/frontend/app/ui/subscriptions/reload/template.hbs
@@ -58,6 +58,20 @@
               />
             </div>
           </p>
+
+          <p class="form__field">
+            <label class="form__label">
+              {{~t "page.subscriptions.reload.form.date"~}}
+            </label>
+
+            <div class="form__input">
+              <Input
+                @value={{this.changeset.date}}
+                class="form__input__text"
+                type="date"
+              />
+            </div>
+          </p>
         </fieldset>
 
         <fieldset class="form__fieldset">

--- a/frontend/translations/de.yaml
+++ b/frontend/translations/de.yaml
@@ -149,6 +149,7 @@ page:
       form:
         hours: Stunden
         minutes: Minuten
+        date: Datum
         submit: Aufladen
         success: Aufladen erfolgreich
 

--- a/frontend/translations/en.yaml
+++ b/frontend/translations/en.yaml
@@ -150,6 +150,7 @@ page:
       form:
         hours: Hours
         minutes: Minutes
+        date: Date
         submit: Submit
         success: Charge successful
 


### PR DESCRIPTION
The form is only shown to admins who should have the ability
to manually set the date.