### PR TITLE
feat(frontend): add CSV export for the subscription list

### DIFF
--- a/frontend/app/helpers/format-duration-short.js
+++ b/frontend/app/helpers/format-duration-short.js
@@ -3,7 +3,7 @@ import startPaddingTag from "customer-center/utils/start-padding-tag";
 import moment from "moment";
 
 export function formatDurationShort(params) {
-  let [duration] = params;
+  let duration = Array.isArray(params) ? params[0] : params;
 
   //remove "-" from negative numbers
   const negative = duration < 0;

--- a/frontend/app/styles/app.scss
+++ b/frontend/app/styles/app.scss
@@ -11,6 +11,7 @@
 @import "pages/index";
 @import "pages/loading";
 @import "pages/subscriptions/detail";
+@import "pages/subscriptions/list";
 @import "pages/subscriptions/own";
 @import "pages/subscriptions/reload";
 

--- a/frontend/app/styles/pages/subscriptions/list.scss
+++ b/frontend/app/styles/pages/subscriptions/list.scss
@@ -1,0 +1,10 @@
+.subscription-export {
+  &__button {
+    @extend .uk-button;
+    @extend .uk-button-default;
+  }
+
+  &__hint {
+    @extend .uk-text-muted;
+  }
+}

--- a/frontend/app/ui/subscriptions/list/controller.js
+++ b/frontend/app/ui/subscriptions/list/controller.js
@@ -3,6 +3,9 @@ import Controller from "@ember/controller";
 import { action } from "@ember/object";
 import { inject as service } from "@ember/service";
 import { tracked } from "@glimmer/tracking";
+import { formatDurationShort } from "customer-center/helpers/format-duration-short";
+import { saveAs } from "file-saver";
+import moment from "moment";
 
 export default class SubscriptionsListController extends Controller {
   @service intl;
@@ -47,6 +50,39 @@ export default class SubscriptionsListController extends Controller {
     this.projects = checked
       ? this._projects.filterBy("isTimeAlmostConsumed")
       : this._projects;
+  }
+
+  @action export() {
+    const headings = [
+      this.intl.t("page.subscriptions.list.table.project"),
+      this.intl.t("page.subscriptions.list.table.customer"),
+      this.intl.t("page.subscriptions.list.table.billing"),
+      this.intl.t("page.subscriptions.list.table.time-purchased"),
+      this.intl.t("page.subscriptions.list.table.time-spent"),
+      this.intl.t("page.subscriptions.list.table.time-total"),
+      this.intl.t("page.subscriptions.list.table.time-unconfirmed"),
+    ].join(",");
+
+    const lines = this.projects
+      .toArray()
+      .map((project) => [
+        project.get("name"),
+        project.get("customer.name"),
+        project.get("billingType.name"),
+        formatDurationShort(project.get("purchasedTime")),
+        formatDurationShort(project.get("spentTime")),
+        formatDurationShort(project.get("totalTime")),
+        formatDurationShort(project.get("unconfirmedTime")),
+      ])
+      .map((line) => line.join(","))
+      .join("\n");
+
+    const name = `cc-subscriptions-${moment().format("YYYY-MM-DD HH:mm")}.csv`;
+    const blob = new Blob([`${headings}\n${lines}`], {
+      type: "text/csv;charset=utf-8",
+    });
+
+    saveAs(blob, name);
   }
 
   setup(model, transition) {

--- a/frontend/app/ui/subscriptions/list/template.hbs
+++ b/frontend/app/ui/subscriptions/list/template.hbs
@@ -92,5 +92,19 @@
       </table>
     </div>
 
+    <p class="subscription-export">
+      <button
+        {{on "click" this.export}}
+        class="subscription-export__button"
+        type="button"
+      >
+        {{~t "page.subscriptions.list.export.label"~}}
+      </button>
+
+      <span class="subscription-export__hint">
+        {{~t "page.subscriptions.list.export.hint"~}}
+      </span>
+    </p>
+
   </div>
 </section>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -80,6 +80,7 @@
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.1.4",
+    "file-saver": "^2.0.5",
     "loader.js": "^4.7.0",
     "moment": "^2.29.0",
     "qunit-dom": "^1.4.0",

--- a/frontend/translations/de.yaml
+++ b/frontend/translations/de.yaml
@@ -90,6 +90,11 @@ page:
       title: Alle Projekte
       empty: Keine Projekte entsprechen dem Filter.
       filter: Zeit fast verbraucht
+      export:
+        label: Als CSV exportieren
+        hint: |
+          Exportiert die aktuelle Ansicht (Sortierung, Filterung)
+          als CSV um in Excel oder ähnliches zu importieren.
 
       table:
         project: Projekt

--- a/frontend/translations/en.yaml
+++ b/frontend/translations/en.yaml
@@ -90,6 +90,11 @@ page:
       title: All projects
       empty: No project match the filters.
       filter: Only show projects where time is almost up.
+      export:
+        label: Export as CSV
+        hint: |
+          Exports the current view (sorting, filtering)
+          as CSV to be imported in Excel or similar.
 
       table:
         project: Project

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7273,6 +7273,11 @@ file-entry-cache@^5.0.1:
   dependencies:
     flat-cache "^2.0.1"
 
+file-saver@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/file-saver/-/file-saver-2.0.5.tgz#d61cfe2ce059f414d899e9dd6d4107ee25670c38"
+  integrity sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA==
+
 file-uri-to-path@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"


### PR DESCRIPTION
This list is needed by backoffice and sales and is currently
manually copy/pasted into their tool of choice.