### PR TITLE
feat(frontend): allow hours as floats when reloading subscriptions

### DIFF
--- a/frontend/app/ui/subscriptions/reload/controller.js
+++ b/frontend/app/ui/subscriptions/reload/controller.js
@@ -40,7 +40,11 @@ export default class SubscriptionsReloadController extends Controller {
     const { hours = 0, minutes = 0, date } = this.changeset.data;
 
     try {
-      const duration = moment.duration({ hours, minutes });
+      // Creating a duration with a float as hours cannot be combined with
+      // minutes. Moment seems to add up correctly but says that it is invalid.
+      const duration = moment.duration({ hours });
+      duration.add(minutes, "minutes");
+
       const ordered = isEmpty(date) ? undefined : moment(date);
 
       await this.timed.placeSubscriptionOrder(this.project, duration, ordered);

--- a/frontend/app/ui/subscriptions/reload/template.hbs
+++ b/frontend/app/ui/subscriptions/reload/template.hbs
@@ -38,9 +38,10 @@
 
             <div class="form__input">
               <Input
+                @type="number"
                 @value={{this.changeset.hours}}
                 class="form__input__text"
-                type="number"
+                step="0.01"
               />
             </div>
           </p>
@@ -52,9 +53,9 @@
 
             <div class="form__input">
               <Input
+                @type="number"
                 @value={{this.changeset.minutes}}
                 class="form__input__text"
-                type="number"
               />
             </div>
           </p>


### PR DESCRIPTION
So 1.25 hours and 5 minutes are added as 1 hour and 20 minutes.