### PR TITLE
fix(frontend): use the getter instead of bracket notation

### DIFF
--- a/frontend/app/ui/subscriptions/list/controller.js
+++ b/frontend/app/ui/subscriptions/list/controller.js
@@ -23,7 +23,7 @@ export default class SubscriptionsListController extends Controller {
     this.projects =
       normalized.length > 0
         ? this._projects.filter((project) => {
-            return project[key].toLowerCase().includes(normalized);
+            return project.get(key).toLowerCase().includes(normalized);
           })
         : this._projects;
   }


### PR DESCRIPTION
Another proxy that will not return the expected value otherwise.