### PR TITLE
fix(frontend): fix problem where different searches would conflict

### DIFF
--- a/frontend/app/ui/components/data-table/heading-search/component.js
+++ b/frontend/app/ui/components/data-table/heading-search/component.js
@@ -3,6 +3,9 @@ import { guidFor } from "@ember/object/internals";
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 
+/**
+ * @arg onSearch
+ */
 export default class DataTableHeadingFilterComponent extends Component {
   @tracked query;
 

--- a/frontend/app/ui/subscriptions/list/template.hbs
+++ b/frontend/app/ui/subscriptions/list/template.hbs
@@ -15,7 +15,7 @@
 
     <p class="form__field">
       <Input
-        {{on "change" this.applyFilter}}
+        {{on "change" this.limitCritical}}
         @type="checkbox"
         class="form__input__checkbox"
         id="form-filter"
@@ -31,17 +31,17 @@
         <thead>
           <tr>
             <th>
-              <DataTable::HeadingSearch @onSearch={{fn this.search "customer.name"}}>
+              <DataTable::HeadingSearch @onSearch={{fn this.searchFor "customer.name"}}>
                 {{t "page.subscriptions.list.table.customer"}}
               </DataTable::HeadingSearch>
             </th>
             <th>
-              <DataTable::HeadingSearch @onSearch={{fn this.search "name"}}>
+              <DataTable::HeadingSearch @onSearch={{fn this.searchFor "name"}}>
                 {{t "page.subscriptions.list.table.project"}}<br>
               </DataTable::HeadingSearch>
             </th>
             <th>
-              <DataTable::HeadingSearch @onSearch={{fn this.search "billingType.name"}}>
+              <DataTable::HeadingSearch @onSearch={{fn this.searchFor "billingType.name"}}>
                 {{t "page.subscriptions.list.table.billing"}}
               </DataTable::HeadingSearch>
             </th>

--- a/frontend/tests/integration/ui/components/data-table/heading-search/component-test.js
+++ b/frontend/tests/integration/ui/components/data-table/heading-search/component-test.js
@@ -1,4 +1,4 @@
-import { render } from "@ember/test-helpers";
+import { click, fillIn, render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { setupRenderingTest } from "ember-qunit";
 import { module, test } from "qunit";
@@ -7,7 +7,36 @@ module("Integration | Component | data-table/heading-search", function (hooks) {
   setupRenderingTest(hooks);
 
   test("it renders", async function (assert) {
-    await render(hbs`<DataTable::HeadingSearch />`);
-    assert.ok(this.element);
+    this.text = "Heading";
+
+    await render(hbs`
+      <DataTable::HeadingSearch>
+        {{this.text}}
+      </DataTable::HeadingSearch>
+    `);
+
+    assert.dom(".data-table__search").exists({ count: 1 });
+    assert.dom(".data-table__search").hasText(this.text);
+
+    assert.dom(".data-table__search__close").exists({ count: 1 });
+    assert.dom(".data-table__search__input").exists({ count: 1 });
+  });
+
+  test("it handles searches", async function (assert) {
+    this.text = "Heading";
+    this.handler = () => assert.step("search");
+    this.query = "Test";
+
+    await render(hbs`
+      <DataTable::HeadingSearch @onSearch={{this.handler}}>
+        {{this.text}}
+      </DataTable::HeadingSearch>
+    `);
+
+    await click(".data-table__search__open");
+    await fillIn(".data-table__search__input", this.query);
+    await click(".data-table__search__close");
+
+    assert.verifySteps(["search", "search"]);
   });
 });


### PR DESCRIPTION
Currently, a second search ignores the first but doesn't update
the corresponding UI element. This update now allows for searches
to be used together.
The sorting is still somewhat broken but that will be fixed later.