### PR TITLE
fix(frontend): update order or project and customer columns

### DIFF
--- a/frontend/app/ui/subscriptions/confirm/template.hbs
+++ b/frontend/app/ui/subscriptions/confirm/template.hbs
@@ -18,8 +18,8 @@
         <table>
           <thead>
             <tr>
-              <th>{{t "page.subscriptions.confirm.table.project"}}</th>
               <th>{{t "page.subscriptions.confirm.table.customer"}}</th>
+              <th>{{t "page.subscriptions.confirm.table.project"}}</th>
               <th>{{t "page.subscriptions.confirm.table.duration"}}</th>
               <th>{{t "page.subscriptions.confirm.table.date"}}</th>
               <th></th>
@@ -29,12 +29,12 @@
           <tbody>
             {{#each this.orders as |order|}}
               <tr>
+                <td>{{order.project.customer.name}}</td>
                 <td>
                   <LinkTo @route="subscriptions.detail" @model={{order.project.id}}>
                     {{order.project.name}}
                   </LinkTo>
                 </td>
-                <td>{{order.project.customer.name}}</td>
                 <td>{{format-duration order.duration}}</td>
                 <td>{{moment-format order.ordered "DD.MM.YYYY"}}</td>
                 <td>

--- a/frontend/app/ui/subscriptions/list/controller.js
+++ b/frontend/app/ui/subscriptions/list/controller.js
@@ -54,8 +54,8 @@ export default class SubscriptionsListController extends Controller {
 
   @action export() {
     const headings = [
-      this.intl.t("page.subscriptions.list.table.project"),
       this.intl.t("page.subscriptions.list.table.customer"),
+      this.intl.t("page.subscriptions.list.table.project"),
       this.intl.t("page.subscriptions.list.table.billing"),
       this.intl.t("page.subscriptions.list.table.time-purchased"),
       this.intl.t("page.subscriptions.list.table.time-spent"),
@@ -66,8 +66,8 @@ export default class SubscriptionsListController extends Controller {
     const lines = this.projects
       .toArray()
       .map((project) => [
-        project.get("name"),
         project.get("customer.name"),
+        project.get("name"),
         project.get("billingType.name"),
         formatDurationShort(project.get("purchasedTime")),
         formatDurationShort(project.get("spentTime")),

--- a/frontend/app/ui/subscriptions/list/template.hbs
+++ b/frontend/app/ui/subscriptions/list/template.hbs
@@ -31,13 +31,13 @@
         <thead>
           <tr>
             <th>
-              <DataTable::HeadingSearch @onSearch={{fn this.search "name"}}>
-                {{t "page.subscriptions.list.table.project"}}<br>
+              <DataTable::HeadingSearch @onSearch={{fn this.search "customer.name"}}>
+                {{t "page.subscriptions.list.table.customer"}}
               </DataTable::HeadingSearch>
             </th>
             <th>
-              <DataTable::HeadingSearch @onSearch={{fn this.search "customer.name"}}>
-                {{t "page.subscriptions.list.table.customer"}}
+              <DataTable::HeadingSearch @onSearch={{fn this.search "name"}}>
+                {{t "page.subscriptions.list.table.project"}}<br>
               </DataTable::HeadingSearch>
             </th>
             <th>
@@ -71,12 +71,12 @@
         <tbody>
           {{#each this.projects as |project|}}
             <tr class={{if project.isTimeAlmostConsumed "uk-alert-danger"}}>
+              <td>{{project.customer.name}}</td>
               <td>
                 <LinkTo @route="subscriptions.detail" @model={{project.id}}>
                   {{project.name}}
                 </LinkTo>
               </td>
-              <td>{{project.customer.name}}</td>
               <td>{{project.billingType.name}}</td>
               <td>{{format-duration-short project.purchasedTime}}</td>
               <td>{{format-duration-short project.spentTime}}</td>


### PR DESCRIPTION
With the values in production it makes more sense to have the
customer name first. Even if the focus is on the project.