### PR TITLE
feat(frontend): add more automated tests

### DIFF
--- a/frontend/app/ui/components/project-info/template.hbs
+++ b/frontend/app/ui/components/project-info/template.hbs
@@ -11,34 +11,34 @@
     <strong class="project-info__title">
       {{t "component.project-info.name"}}
     </strong>
-    {{@project.name}}
+    <span>{{@project.name}}</span>
   </li>
 
   <li class="project-info__item">
     <strong class="project-info__title">
       {{t "component.project-info.customer"}}
     </strong>
-    {{@project.customer.name}}
+    <span>{{@project.customer.name}}</span>
   </li>
 
   <li class="project-info__item">
     <strong class="project-info__title">
       {{t "component.project-info.billing"}}
     </strong>
-    {{@project.billingType.name}}
+    <span>{{@project.billingType.name}}</span>
   </li>
 
   <li class="project-info__item">
     <strong class="project-info__title">
       {{t "component.project-info.time-total"}}
     </strong>
-    {{format-duration @project.totalTime}}
+    <span>{{format-duration @project.totalTime}}</span>
   </li>
 
   <li class="project-info__item">
     <strong class="project-info__title">
       {{t "component.project-info.time-unconfirmed"}}
     </strong>
-    {{format-duration @project.unconfirmedTime}}
+    <span>{{format-duration @project.unconfirmedTime}}</span>
   </li>
 </ul>

--- a/frontend/tests/integration/helpers/format-duration-short-test.js
+++ b/frontend/tests/integration/helpers/format-duration-short-test.js
@@ -1,16 +1,17 @@
 import { render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { setupRenderingTest } from "ember-qunit";
-import { module, skip } from "qunit";
+import { module, test } from "qunit";
 
 module("Integration | Helper | format-duration-short", function (hooks) {
   setupRenderingTest(hooks);
 
-  skip("it renders", async function (assert) {
-    this.set("inputValue", "1234");
+  test("it renders", async function (assert) {
+    //              hours             minutes
+    this.duration = 1000 * 3600 * 2 + 1000 * 60 * 35;
 
-    await render(hbs`{{format-duration-short inputValue}}`);
+    await render(hbs`{{format-duration-short this.duration}}`);
 
-    assert.equal(this.element.textContent.trim(), "1234");
+    assert.dom(this.element).hasText("02:35");
   });
 });

--- a/frontend/tests/integration/helpers/format-duration-test.js
+++ b/frontend/tests/integration/helpers/format-duration-test.js
@@ -1,16 +1,25 @@
 import { render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
+import { setupIntl } from "ember-intl/test-support";
 import { setupRenderingTest } from "ember-qunit";
-import { module, skip } from "qunit";
+import moment from "moment";
+import { module, test } from "qunit";
 
 module("Integration | Helper | format-duration", function (hooks) {
   setupRenderingTest(hooks);
+  setupIntl(hooks, "en");
 
-  skip("it renders", async function (assert) {
-    this.set("inputValue", "1234");
+  test("it renders", async function (assert) {
+    const intl = this.owner.lookup("service:intl");
+    const duration = 1;
+    const durationString = intl.t("helper.format-duration.minutes", {
+      count: duration,
+    });
 
-    await render(hbs`{{format-duration inputValue}}`);
+    this.duration = moment.duration({ minutes: duration });
 
-    assert.equal(this.element.textContent.trim(), "1234");
+    await render(hbs`{{format-duration this.duration}}`);
+
+    assert.dom(this.element).hasText(durationString);
   });
 });

--- a/frontend/tests/integration/ui/components/nav-breadcrumbs/component-test.js
+++ b/frontend/tests/integration/ui/components/nav-breadcrumbs/component-test.js
@@ -7,7 +7,17 @@ module("Integration | Component | nav-breadcrumbs", function (hooks) {
   setupRenderingTest(hooks);
 
   test("it renders", async function (assert) {
-    await render(hbs`<NavBreadcrumbs />`);
-    assert.ok(this.element);
+    this.items = [{ label: "Foo", route: "foo" }, { label: "Bar" }];
+
+    await render(hbs`<NavBreadcrumbs @crumbs={{this.items}} />`);
+
+    assert.dom(".breadcrumbs__home").exists({ count: 1 });
+    assert.dom(".breadcrumbs__item").exists({ count: this.items.length });
+
+    assert.dom(".breadcrumbs__item:nth-child(2)").hasText("Foo");
+    assert.dom(".breadcrumbs__item:nth-child(2) a").exists({ count: 1 });
+
+    assert.dom(".breadcrumbs__item:nth-child(3)").hasText("Bar");
+    assert.dom(".breadcrumbs__item:nth-child(3) span").exists({ count: 1 });
   });
 });

--- a/frontend/tests/integration/ui/components/project-info/component-test.js
+++ b/frontend/tests/integration/ui/components/project-info/component-test.js
@@ -1,12 +1,21 @@
 import { render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
+import { setupIntl } from "ember-intl/test-support";
 import { setupRenderingTest } from "ember-qunit";
-import { module, skip } from "qunit";
+import moment from "moment";
+import { module, test } from "qunit";
 
 module("Integration | Component | project-info", function (hooks) {
   setupRenderingTest(hooks);
+  setupIntl(hooks, "en");
 
-  skip("it renders", async function (assert) {
+  test("it renders", async function (assert) {
+    const intl = this.owner.lookup("service:intl");
+    const duration = 1;
+    const durationString = intl.t("helper.format-duration.minutes", {
+      count: duration,
+    });
+
     this.project = {
       name: "Project #1",
       customer: {
@@ -15,11 +24,25 @@ module("Integration | Component | project-info", function (hooks) {
       billingType: {
         name: "Billing type #1",
       },
-      totalTime: "",
-      unconfirmedTime: "",
+      totalTime: moment.duration({ minutes: duration }),
+      unconfirmedTime: moment.duration({ minutes: duration }),
     };
 
     await render(hbs`<ProjectInfo @project={{this.project}} />`);
-    assert.ok(this.element);
+
+    assert.dom(".project-info__item").exists({ count: 5 });
+
+    assert
+      .dom(".project-info__item:nth-child(1) span")
+      .hasText(this.project.name);
+    assert
+      .dom(".project-info__item:nth-child(2) span")
+      .hasText(this.project.customer.name);
+    assert
+      .dom(".project-info__item:nth-child(3) span")
+      .hasText(this.project.billingType.name);
+
+    assert.dom(".project-info__item:nth-child(4) span").hasText(durationString);
+    assert.dom(".project-info__item:nth-child(5) span").hasText(durationString);
   });
 });

--- a/frontend/tests/integration/ui/components/status-battery/component-test.js
+++ b/frontend/tests/integration/ui/components/status-battery/component-test.js
@@ -3,6 +3,8 @@ import { hbs } from "ember-cli-htmlbars";
 import { setupRenderingTest } from "ember-qunit";
 import { module, test } from "qunit";
 
+const CLASS_WARNING = "status-battery--empty";
+
 module("Integration | Component | status-battery", function (hooks) {
   setupRenderingTest(hooks);
 
@@ -11,6 +13,30 @@ module("Integration | Component | status-battery", function (hooks) {
 
     await render(hbs`<StatusBattery @percentage={{this.percentage}} />`);
 
-    assert.ok(this.element);
+    assert.dom(".status-battery").doesNotHaveClass(CLASS_WARNING);
+    assert.dom(".status-battery__body").hasAttribute("style", /height: 50%/i);
+    assert
+      .dom(".status-battery__body")
+      // 243,216,0 is #F3D800 set through element.style
+      .hasAttribute("style", /background-color: rgb\(243, 216, 0\)/i);
+  });
+
+  test("it has a warning styling", async function (assert) {
+    this.warning = true;
+    this.percentage = 0.05;
+
+    await render(hbs`
+      <StatusBattery
+        @warning={{this.warning}}
+        @percentage={{this.percentage}}
+      />
+    `);
+
+    assert.dom(".status-battery").hasClass(CLASS_WARNING);
+    assert.dom(".status-battery__body").hasAttribute("style", /height: 5%/i);
+    assert
+      .dom(".status-battery__body")
+      // 255,0,0 is #FF0000 set through element.style
+      .hasAttribute("style", /background-color: rgb\(255, 0, 0\)/i);
   });
 });


### PR DESCRIPTION
This adds tests for both duration helpers and updates the tests for
the breadcrumbs and project-info components.