### PR TITLE
fix(frontend): make battery height relative

### DIFF
--- a/frontend/app/styles/components/status-battery.scss
+++ b/frontend/app/styles/components/status-battery.scss
@@ -30,7 +30,7 @@
   }
 
   &__body {
-    height: 50px;
+    height: 100%;
     border-radius: 5px;
     background-color: #6be585;
 


### PR DESCRIPTION
The 50px are currently correct but this should not use absolute values.