### PR TITLE
docs(frontend): add doc-comments to remaining components

### DIFF
--- a/frontend/app/ui/components/data-table/heading-sort/component.js
+++ b/frontend/app/ui/components/data-table/heading-sort/component.js
@@ -2,6 +2,9 @@ import { action } from "@ember/object";
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 
+/**
+ * @arg onSort
+ */
 export default class DataTableHeadingSortComponent extends Component {
   @tracked order;
 

--- a/frontend/app/ui/components/status-battery/component.js
+++ b/frontend/app/ui/components/status-battery/component.js
@@ -15,6 +15,10 @@ const COLORS = [
   "#00E500",
 ];
 
+/**
+ * @arg warning
+ * @arg percentage
+ */
 export default class StatusBatteryComponent extends Component {
   timer = null;
 


### PR DESCRIPTION
For now, these only list the available arguments of the component.
I will add types and descriptions later.