### PR TITLE
fix(frontend): update closeAfter setting

### DIFF
--- a/frontend/app/services/notify.js
+++ b/frontend/app/services/notify.js
@@ -2,8 +2,6 @@ import parseError from "customer-center/utils/parse-error";
 import NotifyService from "ember-notify";
 
 export default class ExtrendedNotifyService extends NotifyService {
-  closeAfter = 5000;
-
   fromError(error) {
     this.error(parseError(error));
   }

--- a/frontend/app/ui/application/template.hbs
+++ b/frontend/app/ui/application/template.hbs
@@ -67,4 +67,4 @@
   {{outlet}}
 </main>
 
-<EmberNotify />
+<EmberNotify @closeAfter={{5000}} />


### PR DESCRIPTION
Setting the timeout as a property on the extending class
is no longer possible with the native class syntax.