### PR TITLE
fix(frontend): use the correct time unit in confirmation dialogs

### DIFF
--- a/frontend/app/ui/subscriptions/confirm/controller.js
+++ b/frontend/app/ui/subscriptions/confirm/controller.js
@@ -5,6 +5,7 @@ import { inject as service } from "@ember/service";
 import UIkit from "uikit";
 
 export default class SubscriptionsConfirmController extends Controller {
+  @service account;
   @service intl;
   @service notify;
   @service timed;
@@ -23,7 +24,7 @@ export default class SubscriptionsConfirmController extends Controller {
     try {
       await UIkit.modal.confirm(
         this.intl.t("page.subscriptions.confirm.prompt.accept", {
-          hours: order.duration.asHours(),
+          duration: order.duration.locale(this.account.language).humanize(),
           customer,
           project,
         })
@@ -53,7 +54,7 @@ export default class SubscriptionsConfirmController extends Controller {
     try {
       await UIkit.modal.confirm(
         this.intl.t("page.subscriptions.confirm.prompt.deny", {
-          hours: order.duration.asHours(),
+          duration: order.duration.locale(this.account.language).humanize(),
           customer,
           project,
         })

--- a/frontend/translations/de.yaml
+++ b/frontend/translations/de.yaml
@@ -116,8 +116,8 @@ page:
       no-access: Ihr Account ist nicht berechtigt Bestellungen zu bestätigen.
 
       prompt:
-        accept: Akzeptieren von {hours} Stunden für {project} von {customer}.
-        deny: Ablehnen von {hours} Stunden für {project} von {customer}.
+        accept: Akzeptieren von {duration} für {project} von {customer}.
+        deny: Ablehnen von {duration} für {project} von {customer}.
 
       table:
         customer: Kunde

--- a/frontend/translations/en.yaml
+++ b/frontend/translations/en.yaml
@@ -116,8 +116,8 @@ page:
       no-access: Your account is not permitted to confirm orders.
 
       prompt:
-        accept: Accepting {hours} hours for {project} of {customer}.
-        deny: Rejecting {hours} hours for {project} of {customer}.
+        accept: Accepting {duration} for {project} of {customer}.
+        deny: Rejecting {duration} for {project} of {customer}.
 
       table:
         customer: Customer


### PR DESCRIPTION
Currently, it is hard-coded to use the hours which leads to ugly
number when confirming minutes. This change uses `.humanize()`
with the user's current locale.

Closes #180 