### PR TITLE
fix(frontend): correct the required access rights

### DIFF
--- a/frontend/app/services/account.js
+++ b/frontend/app/services/account.js
@@ -16,12 +16,17 @@ export default class AccountService extends Service {
     return this.info ? this.info.get("language") : "en";
   }
 
-  get isAdmin() {
-    return this.info ? this.info.groups.includes(ENV.APP.adminGroup) : false;
+  get groups() {
+    return (this.info && this.info.groups) || [];
   }
 
-  get isCustomer() {
-    return this.info ? this.info.groups.includes(ENV.APP.customerGroup) : false;
+  isInGroup(group) {
+    return this.groups.includes(group);
+  }
+
+  isInGroups(amount, groups) {
+    const method = amount === "one" ? "some" : "every";
+    return this.groups[method]((group) => groups.includes(group));
   }
 
   async fetchCurrentUser() {

--- a/frontend/app/ui/application/controller.js
+++ b/frontend/app/ui/application/controller.js
@@ -7,6 +7,10 @@ export default class ApplicationController extends Controller {
   @service session;
   @service intl;
 
+  get showConfirmInMenu() {
+    return this.account.isInGroup("adsy-timed-admin");
+  }
+
   get languages() {
     return this.intl.locales.map((locale) => ({
       key: locale,

--- a/frontend/app/ui/application/template.hbs
+++ b/frontend/app/ui/application/template.hbs
@@ -21,7 +21,7 @@
               </LinkTo>
             </li>
 
-            {{#if this.account.isAdmin}}
+            {{#if this.showConfirmInMenu}}
               <li class="site-header__nav__item">
                 <LinkTo @route="subscriptions.confirm">
                   {{~t "page.application.nav.subscriptions-confirm"~}}

--- a/frontend/app/ui/subscriptions/confirm/route.js
+++ b/frontend/app/ui/subscriptions/confirm/route.js
@@ -8,7 +8,7 @@ export default class SubscriptionsConfirmRoute extends AuthenticatedRoute {
   @service intl;
 
   beforeModel(transition) {
-    if (!this.account.isAdmin) {
+    if (!this.account.isInGroup("adsy-timed-admin")) {
       this.notify.error(this.intl.t("page.subscriptions.confirm.no-access"));
       this.transitionTo("subscriptions.index");
     }

--- a/frontend/app/ui/subscriptions/detail/controller.js
+++ b/frontend/app/ui/subscriptions/detail/controller.js
@@ -15,6 +15,13 @@ export default class SubscriptionsDetailController extends Controller {
   @tracked reports;
   @tracked reportsNext;
 
+  get showReloadButton() {
+    return this.account.isInGroups("one", [
+      "adsy-timed-admin",
+      "adsy-customer",
+    ]);
+  }
+
   get breadcrumbs() {
     return [
       {

--- a/frontend/app/ui/subscriptions/detail/template.hbs
+++ b/frontend/app/ui/subscriptions/detail/template.hbs
@@ -8,7 +8,7 @@
         {{~t "page.subscriptions.detail.title"~}}
       </h1>
 
-      {{#if (or this.account.isAdmin this.account.isCustomer)}}
+      {{#if this.showReloadButton}}
         <LinkTo
           @route="subscriptions.reload"
           @model={{this.project.id}}

--- a/frontend/app/ui/subscriptions/index/route.js
+++ b/frontend/app/ui/subscriptions/index/route.js
@@ -9,7 +9,7 @@ export default class SubscriptionsIndexRoute extends AuthenticatedRoute {
 
     // Only admins get the full list while customers/users
     // get a simple overview over their own projects.
-    if (this.account.isAdmin) {
+    if (this.account.isInGroups("one", ["adsy-user", "adsy-timed-admin"])) {
       this.transitionTo("subscriptions.list");
     } else {
       this.transitionTo("subscriptions.own");

--- a/frontend/app/ui/subscriptions/list/route.js
+++ b/frontend/app/ui/subscriptions/list/route.js
@@ -7,8 +7,8 @@ export default class SubscriptionsListRoute extends AuthenticatedRoute {
 
   beforeModel(transition) {
     // Customers/users don't have access to the full list.
-    if (!this.account.isAdmin) {
-      this.transitionTo("subscriptions.index");
+    if (!this.account.isInGroups("one", ["adsy-user", "adsy-timed-admin"])) {
+      this.transitionTo("subscriptions.own");
     }
   }
 

--- a/frontend/app/ui/subscriptions/own/controller.js
+++ b/frontend/app/ui/subscriptions/own/controller.js
@@ -8,6 +8,13 @@ export default class SubscriptionsOwnController extends Controller {
 
   @alias("model") projects;
 
+  get showReloadLink() {
+    return this.account.isInGroups("one", [
+      "adsy-timed-admin",
+      "adsy-customer",
+    ]);
+  }
+
   breadcrumbs = [
     { label: this.intl.t("page.subscriptions.title"), route: "subscriptions" },
     { label: this.intl.t("page.subscriptions.own.title") },

--- a/frontend/app/ui/subscriptions/own/route.js
+++ b/frontend/app/ui/subscriptions/own/route.js
@@ -3,14 +3,6 @@ import AuthenticatedRoute from "customer-center/routes/-authenticated";
 
 export default class SubscriptionsOwnRoute extends AuthenticatedRoute {
   @service timed;
-  @service account;
-
-  beforeModel(transition) {
-    // Admins have too many projects for this view.
-    if (this.account.isAdmin) {
-      this.transitionTo("subscriptions.index");
-    }
-  }
 
   model() {
     return this.timed.getOwnProjects();

--- a/frontend/app/ui/subscriptions/own/template.hbs
+++ b/frontend/app/ui/subscriptions/own/template.hbs
@@ -60,7 +60,7 @@
                   {{~t "page.subscriptions.own.projects.details"~}}
                 </LinkTo>
 
-                {{#if this.account.isCustomer}}
+                {{#if this.showReloadLink}}
                   <LinkTo @route="subscriptions.reload" @model={{project.id}}>
                     {{~t "page.subscriptions.own.projects.reload"~}}
                   </LinkTo>

--- a/frontend/app/ui/subscriptions/reload/controller.js
+++ b/frontend/app/ui/subscriptions/reload/controller.js
@@ -17,6 +17,14 @@ export default class SubscriptionsReloadController extends Controller {
   @tracked packages;
   @tracked changeset;
 
+  get showForm() {
+    return this.account.isInGroup("adsy-timed-admin");
+  }
+
+  get showPackages() {
+    return this.account.isInGroups("all", ["timed", "adsy-customer"]);
+  }
+
   get breadcrumbs() {
     return [
       {

--- a/frontend/app/ui/subscriptions/reload/route.js
+++ b/frontend/app/ui/subscriptions/reload/route.js
@@ -8,14 +8,14 @@ export default class SubscriptionsReloadRoute extends AuthenticatedRoute {
   @service intl;
 
   beforeModel(transition) {
-    // Normal users cannot recharge the subscription.
-    if (!this.account.isAdmin && !this.account.isCustomer) {
+    if (
+      !this.account.isInGroups("one", ["adsy-timed-admin", "adsy-customer"])
+    ) {
       this.notify.error(this.intl.t("page.subscriptions.reload.no-access"));
       this.transitionTo(
         "subscriptions.detail",
         transition.to.params.project_id
       );
-      return;
     }
   }
 
@@ -24,7 +24,7 @@ export default class SubscriptionsReloadRoute extends AuthenticatedRoute {
 
     // Customers get a list of packages to choose from.
     let packages = [];
-    if (this.account.isCustomer) {
+    if (this.account.isInGroup("adsy-customer")) {
       const billing_type = project.billingType.get("id");
       packages = await this.timed.getReloadPackages(billing_type);
     }

--- a/frontend/app/ui/subscriptions/reload/template.hbs
+++ b/frontend/app/ui/subscriptions/reload/template.hbs
@@ -22,7 +22,7 @@
   </div>
 </section>
 
-{{#if this.account.isAdmin}}
+{{#if this.showForm}}
   <section class="section">
     <div class="section__inner">
 
@@ -92,7 +92,7 @@
   </section>
 {{/if}}
 
-{{#if this.account.isCustomer}}
+{{#if this.showPackages}}
   <section class="section">
     <div class="section__inner">
 

--- a/frontend/config/environment.js
+++ b/frontend/config/environment.js
@@ -29,10 +29,6 @@ module.exports = function (environment) {
     },
 
     APP: {
-      // These are used in the account service.
-      adminGroup: "adsy-timed-admin",
-      customerGroup: "adsy-customer",
-
       // Define alertTime in hours.
       // When total time comes close to alertTime, text color changes.
       alertTime: 5,


### PR DESCRIPTION
I chose a simple isAdmin/isCustomer model and didn't realize that
this will not work to implement the previous requirements. This
change drops the isWhatever and instead introduces methods to
check if the user is in one or multiple groups. This is in essence
the system we had before.

Closes #179 