### PR TITLE
fix(frontend): add spacing and improve wrapping of export button

### DIFF
--- a/frontend/app/styles/pages/subscriptions/list.scss
+++ b/frontend/app/styles/pages/subscriptions/list.scss
@@ -2,9 +2,11 @@
   &__button {
     @extend .uk-button;
     @extend .uk-button-default;
+    @extend .uk-margin-right;
   }
 
   &__hint {
     @extend .uk-text-muted;
+    @extend .uk-display-inline-block;
   }
 }


### PR DESCRIPTION
This adds a margin and inline-block to improve wrapping.