### PR TITLE
fix(frontend): update Node version used in GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 14
 
       - name: Install dependencies
         run: yarn --cwd=frontend install
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 14
 
       - name: Install dependencies (no lockfile)
         run: yarn --cwd=frontend install --no-lockfile


### PR DESCRIPTION
No need to keep using version 10 here.