### PR TITLE
fix(frontend): redirect on 401 instead of showing error

### DIFF
--- a/frontend/app/adapters/application.js
+++ b/frontend/app/adapters/application.js
@@ -15,4 +15,12 @@ export default class ApplicationAdapter extends JSONAPIAdapter {
 
     return headers;
   }
+
+  handleResponse(status, headers, payload, requestData) {
+    if (status === 401 && this.session.isAuthenticated) {
+      this.session.invalidate();
+    }
+
+    return super.handleResponse(...arguments);
+  }
 }

--- a/frontend/app/routes/-authenticated.js
+++ b/frontend/app/routes/-authenticated.js
@@ -1,10 +1,13 @@
+import { UnauthorizedError } from "@ember-data/adapter/error";
+import { action } from "@ember/object";
 import { inject as service } from "@ember/service";
+import config from "customer-center/config/environment";
 import BaseRoute from "customer-center/routes/-base";
 
 export default class AuthenticatedRoute extends BaseRoute {
   @service session;
 
   beforeModel(transition) {
-    this.session.requireAuthentication(transition, "account.login");
+    this.session.requireAuthentication(transition, config.APP.loginRoute);
   }
 }

--- a/frontend/app/ui/account/login/route.js
+++ b/frontend/app/ui/account/login/route.js
@@ -1,6 +1,13 @@
+import { inject as service } from "@ember/service";
 import BaseRoute from "customer-center/routes/-base";
 
 export default class AccountLoginRoute extends BaseRoute {
+  @service session;
+
+  beforeModel(transition) {
+    this.session.prohibitAuthentication("index");
+  }
+
   model() {
     return {
       username: "",

--- a/frontend/app/ui/account/password-confirm/route.js
+++ b/frontend/app/ui/account/password-confirm/route.js
@@ -1,6 +1,13 @@
 import Route from "@ember/routing/route";
+import { inject as service } from "@ember/service";
 
 export default class AccountPasswordConfirmRoute extends Route {
+  @service session;
+
+  beforeModel(transition) {
+    this.session.prohibitAuthentication("index");
+  }
+
   async model(params) {
     const { token } = params;
 

--- a/frontend/app/ui/error/controller.js
+++ b/frontend/app/ui/error/controller.js
@@ -1,0 +1,12 @@
+import Controller from "@ember/controller";
+import { inject as service } from "@ember/service";
+import config from "customer-center/config/environment";
+
+export default class ErrorController extends Controller {
+  @service intl;
+
+  /** Don't show internals in production. */
+  showStack = config.environment !== "production";
+
+  breadcrumbs = [{ label: this.intl.t("page.error.title") }];
+}

--- a/frontend/app/ui/error/template.hbs
+++ b/frontend/app/ui/error/template.hbs
@@ -1,9 +1,7 @@
 <section class="page-header">
   <div class="page-header__inner">
 
-    <NavBreadcrumbs @crumbs={{array
-      (hash label=(t "page.error.title"))
-    }} />
+    <NavBreadcrumbs @crumbs={{this.breadcrumbs}} />
 
     <h1 class="page-header__title">
       {{~t "page.error.title"~}}
@@ -17,7 +15,9 @@
 
     <p>{{this.model.message}}</p>
 
-    <pre>{{this.model.stack}}</pre>
+    {{#if this.showStack}}
+      <pre>{{this.model.stack}}</pre>
+    {{/if}}
 
   </div>
 </section>

--- a/frontend/app/ui/subscriptions/confirm/route.js
+++ b/frontend/app/ui/subscriptions/confirm/route.js
@@ -8,6 +8,8 @@ export default class SubscriptionsConfirmRoute extends AuthenticatedRoute {
   @service intl;
 
   beforeModel(transition) {
+    super.beforeModel(transition);
+
     if (!this.account.isInGroup("adsy-timed-admin")) {
       this.notify.error(this.intl.t("page.subscriptions.confirm.no-access"));
       this.transitionTo("subscriptions.index");

--- a/frontend/app/ui/subscriptions/list/route.js
+++ b/frontend/app/ui/subscriptions/list/route.js
@@ -6,6 +6,8 @@ export default class SubscriptionsListRoute extends AuthenticatedRoute {
   @service account;
 
   beforeModel(transition) {
+    super.beforeModel(transition);
+
     // Customers/users don't have access to the full list.
     if (!this.account.isInGroups("one", ["adsy-user", "adsy-timed-admin"])) {
       this.transitionTo("subscriptions.own");

--- a/frontend/app/ui/subscriptions/reload/route.js
+++ b/frontend/app/ui/subscriptions/reload/route.js
@@ -8,6 +8,9 @@ export default class SubscriptionsReloadRoute extends AuthenticatedRoute {
   @service intl;
 
   beforeModel(transition) {
+    super.beforeModel(transition);
+
+    // Normal users cannot recharge the subscription.
     if (
       !this.account.isInGroups("one", ["adsy-timed-admin", "adsy-customer"])
     ) {

--- a/frontend/config/environment.js
+++ b/frontend/config/environment.js
@@ -29,6 +29,8 @@ module.exports = function (environment) {
     },
 
     APP: {
+      loginRoute: "account.login",
+
       // Define alertTime in hours.
       // When total time comes close to alertTime, text color changes.
       alertTime: 5,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -70,7 +70,7 @@
     "ember-notify": "^6.0.0",
     "ember-qunit": "^4.6.0",
     "ember-resolver": "^8.0.2",
-    "ember-simple-auth": "^3.1.0-beta.0",
+    "ember-simple-auth": "3.1.0",
     "ember-source": "~3.21.1",
     "ember-template-lint": "^2.11.0",
     "ember-truth-helpers": "^2.1.0",

--- a/frontend/tests/unit/ui/error/controller-test.js
+++ b/frontend/tests/unit/ui/error/controller-test.js
@@ -1,0 +1,11 @@
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+
+module("Unit | Controller | error", function (hooks) {
+  setupTest(hooks);
+
+  test("it shows stack in testing", function (assert) {
+    const controller = this.owner.lookup("controller:error");
+    assert.equal(controller.showStack, true);
+  });
+});

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6388,10 +6388,10 @@ ember-runtime-enumerable-includes-polyfill@^2.0.0:
     ember-cli-babel "^6.9.0"
     ember-cli-version-checker "^2.1.0"
 
-ember-simple-auth@^3.1.0-beta.0:
-  version "3.1.0-beta.0"
-  resolved "https://registry.yarnpkg.com/ember-simple-auth/-/ember-simple-auth-3.1.0-beta.0.tgz#283dde8f8ab68aa83360e650ddae39bc652eab4d"
-  integrity sha512-QKhuFD32a0eWUGySp/3oR9aWOwsvmqR+Q1CfMHn3xRR8H0xintE2CjwUEZLMjrC0ixEXzpCu60Gjrltdrbhqzw==
+ember-simple-auth@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/ember-simple-auth/-/ember-simple-auth-3.1.0.tgz#e8abe27f6c3c44f46ebacace57364e82223bab9a"
+  integrity sha512-JS8NtYAlSftkoQh36Kxps6iLHTP/InIgKt8w21QBHCTqDx07af4aka59GojaBvc+8GubQuGKldk6vvw3R8bwxA==
   dependencies:
     base-64 "^0.1.0"
     broccoli-file-creator "^2.0.0"


### PR DESCRIPTION
This also includes some other improvements related to the session
handling. The main fix is to check for UnauthorizedError in a new
error action of the -authenticated route.

```js
@action error(error, transition) {
  if (error instanceof UnauthorizedError) {
    this.transitionTo("account.login");
    return false;
  }

  return true;
}
```

Fixes #187 