### PR TITLE
fix(frontend): remove floating dependency tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,12 +43,6 @@ jobs:
         with:
           node-version: 14
 
-      - name: Install dependencies (no lockfile)
-        run: yarn --cwd=frontend install --no-lockfile
-
-      - name: Run tests (floating dependencies)
-        run: yarn --cwd=frontend test
-
       - name: Install dependencies
         run: yarn --cwd=frontend install
 

--- a/README.md
+++ b/README.md
@@ -42,4 +42,4 @@ make deploy
 
 ### LDAP
 
-To authenticate against LDAP, we used the [Passport LDAP authentication strategy](https://github.com/vesse/passport-ldapauth)
+To authenticate against LDAP, we used the [Passport LDAP authentication strategy](https://github.com/vesse/passport-ldapauth).


### PR DESCRIPTION
Seems I forgot to remove them when copying an existing workflow.
But, as this is a project we only test with a lockfile.