### PR TITLE
feat(backend): add debugger configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@
 .directory
 
 # Editors
-.vscode
+.vscode/*
+!.vscode/launch.json
 *.swp
 
 # Node

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Backend",
+      "type": "node",
+      "request": "attach",
+      "port": 9229,
+      "address": "localhost",
+      "localRoot": "${workspaceFolder}/backend",
+      "remoteRoot": "/usr/src/app",
+      "protocol": "inspector",
+      "restart": true
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ Configure the endpoints as needed.
 Run `make serve-local` to start the frontend directly.
 
 The default password for all users is `123qweasd`.
+### Debugger
+To attach a debugger you need to run the backend with `yarn debug` (in the container). There is a configuration file for VSCode but you can use any Node debugger to attach to the service.
+
 
 ## Deployment
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,6 +15,7 @@
   ],
   "scripts": {
     "start": "node --require=@babel/register app/start.js",
+    "debug": "node --inspect=0.0.0.0:9229 --require=@babel/register app/start.js",
     "watch": "nodemon --exec yarn start",
     "build": "babel app -d dist",
     "serve": "node dist/start.js",


### PR DESCRIPTION
Because the console is a terrible way to debug an environment :smile: 