### PR TITLE
fix(release-container-image.yaml): do not login on pr

### DIFF
--- a/.github/workflows/release-container-image.yaml
+++ b/.github/workflows/release-container-image.yaml
@@ -50,12 +50,14 @@ jobs:
           echo ::set-output name=version::${VERSION}
           echo ::set-output name=tags::${TAGS}
           echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+
       - name: Login to GHCR
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.PAT }}
+        if: ${{ github.event_name != 'pull_request' }}
 
       - name: Build and push
         id: docker_build
@@ -115,12 +117,14 @@ jobs:
           echo ::set-output name=version::${VERSION}
           echo ::set-output name=tags::${TAGS}
           echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+
       - name: Login to GHCR
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.PAT }}
+        if: ${{ github.event_name != 'pull_request' }}
 
       - name: Build and push
         id: docker_build


### PR DESCRIPTION
PR branches should not login into ghcr.io, as forks don't work because the PAT isn't shared with them. Which is good. 

There is really no need to login, as we just want to test the build of the image.