### PR TITLE
docs: remove obsolete section about the configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,6 @@ Adfinis customer support portal with LDAP and Timed integration.
 * `cd customer-center`
 * `make init`
 
-### Configuration
-
-*Info: for development setup see Development*
-
-Set `ldap.bindCredentials` and `services.timed.password` in `backend/config.js` to their respective passwords.
-
-To use the timedbackend service you need to configure the api user in the django admin.
-
-Configure the endpoints as needed.
-
 ## Development
 
 Run `make serve-local` to start the frontend directly.


### PR DESCRIPTION
The configuration is now rather straight forward for anyone who
previously worked with Docker containers. What would be nice is
a description for every configuration option. This can now be done
through Convict but it would be a major undertaking.