### PR TITLE
fix(oidc): perform logout on the server

### DIFF
--- a/frontend/app/application/controller.js
+++ b/frontend/app/application/controller.js
@@ -24,6 +24,6 @@ export default class ApplicationController extends Controller {
   }
 
   @action invalidateSession() {
-    this.session.invalidate();
+    this.session.singleLogout();
   }
 }


### PR DESCRIPTION
If the logout is performed on the application level only, the server
will still hold a valid token and therefore perform a login right
after the logout, resulting in not being able to log out from the
application.