### PR TITLE
fix(subscription/reload): calculate total hours manually

### DIFF
--- a/frontend/app/subscriptions/reload/controller.js
+++ b/frontend/app/subscriptions/reload/controller.js
@@ -8,6 +8,16 @@ import { Changeset } from "ember-changeset";
 import moment from "moment";
 import UIkit from "uikit";
 
+/**
+ * Format duration to HH:mm. Since duration.hours() is always less or equal to 24,
+ * remaining hours need to be added if the duration exceeds 24 hours.
+ */
+function format(duration) {
+  const totalHours = duration.hours() + 24 * duration.days();
+
+  return `${totalHours}:${duration.minutes()}:00`;
+}
+
 export default class SubscriptionsReloadController extends Controller {
   @service account;
   @service notify;
@@ -78,7 +88,7 @@ export default class SubscriptionsReloadController extends Controller {
         return;
       }
 
-      await this.timed.placeSubscriptionOrder(this.project, duration);
+      await this.timed.placeSubscriptionOrder(this.project, format(duration));
 
       this.notify.success(
         this.intl.t("page.subscriptions.reload.packages.success")

--- a/frontend/app/transforms/django-duration.js
+++ b/frontend/app/transforms/django-duration.js
@@ -42,7 +42,10 @@ export default class DjangoDurationTransform extends Transform {
    */
   serialize(deserialized) {
     if (!moment.isDuration(deserialized)) {
-      return null;
+      console.warn(
+        "Transform Django Duration: Non-duration value has been received."
+      );
+      return deserialized;
     }
 
     const { days, hours, minutes, seconds, microseconds } =


### PR DESCRIPTION
The backend expects the duration of a subscription package in the
format `HH:mm:ss`. Our  previous implementation failed if the
duration exceeded 24 hours.

For instance, if the duration was 30 hours, it was given in the
format `DD HH:mm:ss` which the backend did not expect. Now, the
calculation of total hours is done manually and not via Moment.js,
as there is not a feasible solution for `DD HH:mm:ss` -> `HH:mm:ss`.

Furthermore, the transform has been updated to not throw an error
when serializing a non-moment-duration value.