### PR TITLE
fix(translations): rename total to remaining

### DIFF
--- a/frontend/app/components/project-info/template.hbs
+++ b/frontend/app/components/project-info/template.hbs
@@ -30,7 +30,7 @@
 
   <li class="project-info__item">
     <strong class="project-info__title">
-      {{t "component.project-info.time-total"}}
+      {{t "component.project-info.time-remaining"}}
     </strong>
     <span>{{format-duration @project.totalTime}}</span>
   </li>

--- a/frontend/app/subscriptions/list/template.hbs
+++ b/frontend/app/subscriptions/list/template.hbs
@@ -67,7 +67,7 @@
             </th>
             <th>
               <DataTable::HeadingSort @onSort={{fn this.sortDuration "totalTime"}}>
-                {{t "page.subscriptions.list.table.time-total"}}
+                {{t "page.subscriptions.list.table.time-remaining"}}
               </DataTable::HeadingSort>
             </th>
             <th>

--- a/frontend/app/subscriptions/own/template.hbs
+++ b/frontend/app/subscriptions/own/template.hbs
@@ -44,7 +44,7 @@
                   <dt>{{t "page.subscriptions.own.projects.time-spent"}}</dt>
                   <dd>{{format-duration project.spentTime}}</dd>
 
-                  <dt>{{t "page.subscriptions.own.projects.time-total"}}</dt>
+                  <dt>{{t "page.subscriptions.own.projects.time-remaining"}}</dt>
                   <dd>
                     {{format-duration project.totalTime}}
 

--- a/frontend/translations/de.yaml
+++ b/frontend/translations/de.yaml
@@ -48,7 +48,7 @@ page:
       projects:
         time-purchased: Bestellte Zeit
         time-spent: Gebuchtes Guthaben
-        time-total: Totales Guthaben
+        time-remaining: Restguthaben
         details: Details
         reload: Aufladen
 
@@ -70,7 +70,7 @@ page:
         cost-center: Kostenstelle
         time-purchased: Bestellte Zeit
         time-spent: Gebuchtes Guthaben
-        time-total: Totales Guthaben
+        time-remaining: Restguthaben
         time-unconfirmed: Ausstehende Zeit
 
 
@@ -159,7 +159,7 @@ component:
     name: Projekt
     customer: Kunde
     billing: Verrechnungsart
-    time-total: Totales Guthaben
+    time-remaining: Restguthaben
     time-unconfirmed: Ausstehende Zeit
 
 

--- a/frontend/translations/en.yaml
+++ b/frontend/translations/en.yaml
@@ -48,7 +48,7 @@ page:
       projects:
         time-purchased: Timed ordered
         time-spent: Time used
-        time-total: Time total
+        time-remaining: Time remaining
         details: Details
         reload: Recharge
 
@@ -70,7 +70,7 @@ page:
         cost-center: Cost center
         time-purchased: Timed ordered
         time-spent: Time used
-        time-total: Time total
+        time-remaining: Time remaining
         time-unconfirmed: Needs confirmation
 
 
@@ -159,7 +159,7 @@ component:
     name: Project
     customer: Customer
     billing: Billing type
-    time-total: Time total
+    time-remaining: Time remaining
     time-unconfirmed: Needs confirmation
 
 


### PR DESCRIPTION
The remaining time has been displayed as total time until now and
that is wrong. There is the `ordered time`, which is the total
duration of placed orders and there is the `remaining time`, which
is (`ordered time` - `reported time`).